### PR TITLE
Prevent illegal id

### DIFF
--- a/newarch.py
+++ b/newarch.py
@@ -114,7 +114,8 @@ if inputlist:
         Counter = -1  # How many spots have we drawn?
         for i in range(len(partylist)):
             # Make each party's blocks an svg group
-            tempstring = '  <g style="fill:{0}; stroke-width:{1:.2f}; stroke:{2}" id="{3}">'.format(partylist[i][2], float(partylist[i][3])*radius*100, partylist[i][4], ''.join(partylist[i][0].split())) 
+            sanitizedpartyname = re.sub(r'[^a-zA-Z0-9_-]', '-', partylist[i][0])
+            tempstring = '  <g style="fill:{0}; stroke-width:{1:.2f}; stroke:{2}" id="{3}">'.format(partylist[i][2], float(partylist[i][3])*radius*100, partylist[i][4], sanitizedpartyname)
             outfile.write(tempstring+'\n')
             for Counter in range(Counter+1, Counter+partylist[i][1]+1):
                 tempstring = '    <circle cx="{0:.2f}" cy="{1:.2f}" r="{2:.2f}"/>'.format(

--- a/newarch.py
+++ b/newarch.py
@@ -2,7 +2,6 @@
 import cgi
 import re
 import math
-import random
 import datetime
 import sys
 import os


### PR DESCRIPTION
### Problem in current version
If a user input special characters in a party name (such as : "A&B coalition"), the python will create an element such as  `<g id="A&B coalition">` which is an illegal id, corrupting the generated file.

### Solution implemented
I just sanitized the inputed string, by replacing any non a-z, A-Z, 0-9, - and _ chars with an hyphen before creating the `<g>`'s id. Hence, "A&B coalition" will generate a `<g id="A-B coalition">` element.

### Regression that isn't really one
If 2 parties are named like "S P" and "S-P", they will both generate a `<g id="S-P">` element. Which is illegal. I don't consider this a regression because it was already possible to have 2 `<g>` elements with the same id, if the user inputed several parties with the same name.

### Issue solved
#77 