### PR TITLE
Better small parliament

### DIFF
--- a/newarch.py
+++ b/newarch.py
@@ -9,7 +9,7 @@ import os
 # Initialize useful calculated fields:
 # Total number of seats per number of rows in diagram:
 TOTALS = [
-    4, 15, 33, 61, 95, 138, 189, 247, 313, 388, 469, 559, 657, 762, 876,  997,
+    3, 15, 33, 61, 95, 138, 189, 247, 313, 388, 469, 559, 657, 762, 876,  997,
     1126, 1263, 1408, 1560, 1722, 1889, 2066, 2250, 2442, 2641, 2850, 3064,
     3289, 3519, 3759, 4005, 4261, 4522, 4794, 5071, 5358, 5652, 5953, 6263,
     6581, 6906, 7239, 7581, 7929, 8287, 8650, 9024, 9404, 9793, 10187, 10594,
@@ -220,7 +220,7 @@ def optimize_rows(nb_delegates, theoritical_nb_rows):
         # This 2 lines formula was determined by @slashme's math
         magic_number = 3.0 * theoritical_nb_rows + 4.0 * i - 2.0
         max_spot_in_row = math.pi / (2 * math.asin(2.0 / magic_number))
-        handled_spots += round(max_spot_in_row)
+        handled_spots += int(max_spot_in_row)
         rows_needed += 1
         if handled_spots >= nb_delegates:
             nb_useless_rows = i - 1

--- a/newarch.py
+++ b/newarch.py
@@ -42,7 +42,7 @@ def main():
     elif inputlist:
         print(treat_inputlist(inputlist, start_time, request_hash, logfile))
     else:
-        logfile.write('No inputlist')
+        logfile.write('No inputlist\n')
     logfile.close()
 
 def treat_inputlist(input_list, start_time, request_hash, logfile):
@@ -246,10 +246,13 @@ def append_row_spots_positions(
     """
     sin_r_rr = math.sin(spot_radius / row_radius)
     for i in range(nb_seats_to_place):
-        angle = float(i)                               \
-                    * (math.pi - 2.0 * sin_r_rr)       \
-                    / (float(nb_seats_to_place) - 1.0) \
-                + sin_r_rr
+        if nb_seats_to_place == 1:
+            angle = math.pi / 2.0
+        else:
+            angle = float(i)                               \
+                        * (math.pi - 2.0 * sin_r_rr)       \
+                        / (float(nb_seats_to_place) - 1.0) \
+                    + sin_r_rr
         spots_positions.append([
             angle,
             row_radius * math.cos(angle) + 1.75,

--- a/newarch.py
+++ b/newarch.py
@@ -154,7 +154,7 @@ def get_spots_centers(nb_delegates, nb_rows, spot_radius):
     Parameters
     ----------
     nb_delegates : int
-    nb_rows : int
+    max_nb_rows : int
     spot_radius : float
 
     Return
@@ -162,15 +162,51 @@ def get_spots_centers(nb_delegates, nb_rows, spot_radius):
     list<3-list<float>>
         The position of each single spot, represented as a list [angle, x, y]
     """
+    discarded_rows, diagram_fullness = optimize_rows(nb_delegates, nb_rows)
     positions = []
-    for i in range(1, nb_rows):  # Fill the n-1 firsts rows
-        add_ith_row_spots(positions, nb_delegates, nb_rows, i, spot_radius)
+    for i in range(1 + discarded_rows, nb_rows):  # Fill the n-1 firsts rows
+        add_ith_row_spots(positions, nb_rows, i, spot_radius, diagram_fullness)
     add_last_row_spots(positions, nb_delegates, nb_rows, spot_radius)
     positions.sort(reverse=True)
     return positions
 
 
-def add_ith_row_spots(spots_positions, nb_delegates, nb_rows, i, spot_radius):
+def optimize_rows(nb_delegates, theoritical_nb_rows):
+    """
+    The number of seats may be small enough so we don't need to fill all the
+    possible rows, but only the outermost ones. This says how much do we
+    actually need.
+
+    Parameters
+    ----------
+    nb_delegates : int
+    theoritical_nb_rows : int
+        The maximum number of rows we can fit in this diagram
+
+    Return
+    ------
+    int
+        The number of innermost rows to discard
+    float
+        The diagram fullness
+    """
+    handled_spots = 0
+    rows_needed = 0
+    for i in range(theoritical_nb_rows, 0, -1):
+        # How many spots can we fit in each row
+        # This 2 lines formula was determined by @slashme's math
+        magic_number = 3.0 * theoritical_nb_rows + 4.0 * i - 2.0
+        max_spot_in_row = math.pi / (2 * math.asin(2.0 / magic_number))
+        handled_spots += round(max_spot_in_row)
+        rows_needed += 1
+        if handled_spots >= nb_delegates:
+            nb_useless_rows = i - 1
+            diagram_fullness = float(nb_delegates) / handled_spots
+            return nb_useless_rows, diagram_fullness
+
+
+def add_ith_row_spots(spots_positions, nb_rows, i,
+                      spot_radius, diagram_fullness):
     """
     Assign spots to a row.
 
@@ -178,14 +214,13 @@ def add_ith_row_spots(spots_positions, nb_delegates, nb_rows, i, spot_radius):
     ----------
     spots_positions : list<3-list<float>>
         New positions will be appened to this list.
-    nb_delegates : int
     nb_rows : int
     i : int
         The number of the current row (1 being the centermost one)
     spot_radius : float
+    diagram_fullness : float
+        What proportion of the diagram is used
     """
-    diagram_fullness = float(nb_delegates) / TOTALS[nb_rows - 1]
-
     # Each row can contain pi/(2asin(2/(3n+4i-2))) spots, where n is the
     # number of rows and i is the number of the current row.
     magic_number = 3.0 * nb_rows + 4.0 * i - 2.0


### PR DESCRIPTION
## What does that do?

In diagram that are "small" (ie: near the lowest bound of their tier, in the TOTAL list), refuses to fill the innermost rows, in order to have denser populated outermost rows

## Issues implemented

#4 and #39 

## Tests

Here be few SVGs generated by this version : [examples-smalldiagram-svg.zip](https://github.com/slashme/parliamentdiagram/files/6447325/examples-smalldiagram-svg.zip)

## Drawbacks?

I think some graph look weird because they are thin (see my tests' example `34.svg`). But I also think this is worth it, considering how prettier became diagrams such as `5.svg` or `9.svg`

## Requirements

This is a request to pull the branch `Rade-Mathis:better-small-parliament` which is based on the top of `Rade-Mathis:newarch-code-cleaning`. The latest one is pull-requested by #96.

I don't know how GitHub's pull-requests work. So I'll advise to treat #96 before this one. If something wrong or weird happens when trying to pull this one, I'll make a new one after #96 has been pulled.