### PR TITLE
Revamp seats placement and other math

### DIFF
--- a/newarch.py
+++ b/newarch.py
@@ -7,19 +7,6 @@ import sys
 import os
 import json
 
-# Initialize useful calculated fields:
-# Total number of seats per number of rows in diagram:
-TOTALS = [
-    3, 15, 33, 61, 95, 138, 189, 247, 313, 388, 469, 559, 657, 762, 876,  997,
-    1126, 1263, 1408, 1560, 1722, 1889, 2066, 2250, 2442, 2641, 2850, 3064,
-    3289, 3519, 3759, 4005, 4261, 4522, 4794, 5071, 5358, 5652, 5953, 6263,
-    6581, 6906, 7239, 7581, 7929, 8287, 8650, 9024, 9404, 9793, 10187, 10594,
-    11003, 11425, 11850, 12288, 12729, 13183, 13638, 14109, 14580, 15066, 15553,
-    16055, 16557, 17075, 17592, 18126, 18660, 19208, 19758, 20323, 20888, 21468,
-    22050, 22645, 23243, 23853, 24467, 25094, 25723, 26364, 27011, 27667, 28329,
-    29001, 29679, 30367, 31061
-]
-
 LOGFILE = None  # A file to log everything we want
 
 def main():
@@ -159,8 +146,6 @@ def count_delegates(party_list):
     sum = 0
     for party in party_list:
         sum += party['nb_seats']
-        if sum > TOTALS[-1]:  # Can't handle such big number
-            return 0
     return sum
 
 
@@ -176,9 +161,35 @@ def get_number_of_rows(nb_delegates):
     ------
     int
     """
-    for i in range(len(TOTALS)):
-        if TOTALS[i] >= nb_delegates:
-            return i + 1
+    i = 0
+    while True:
+        i += 1
+        if Totals(i) >= nb_delegates:
+            return i
+
+
+def Totals(i):
+    """
+    Total number of seats per number of rows in diagram.
+
+    Parameters
+    ----------
+    i : int
+        A number of rows of seats
+
+    Return
+    ------
+    int
+        The maximal number of seats available for that number of rows
+    """
+    if isinstance(i, int) and (i >= 0):
+        rows = i + 1
+        tot = 0
+        rad = 1/float(4*rows-2)
+        for r in range(1, rows+1):
+            R = .5 + 2*(r-1)*rad
+            tot += int(math.pi*R/(2*rad))
+        return tot
 
 
 def get_spots_centers(nb_delegates, nb_rows, spot_radius, dense_rows):
@@ -199,7 +210,7 @@ def get_spots_centers(nb_delegates, nb_rows, spot_radius, dense_rows):
         discarded_rows, diagram_fullness = optimize_rows(nb_delegates, nb_rows)
     else:
         discarded_rows = 0
-        diagram_fullness = float(nb_delegates) / TOTALS[nb_rows - 1]
+        diagram_fullness = float(nb_delegates) / Totals(nb_rows)
 
     positions = []
     for i in range(1 + discarded_rows, nb_rows):  # Fill the n-1 firsts rows

--- a/newarch.py
+++ b/newarch.py
@@ -93,7 +93,7 @@ def treat_inputlist(input_list, start_time, request_hash):
     if sum_delegates > 0:
         nb_rows = get_number_of_rows(sum_delegates)
         # Maximum radius of spot is 0.5/nb_rows; leave a bit of space.
-        radius = 0.4 / nb_rows
+        radius = 1. / (4*nb_rows-2)
 
         pos_list = get_spots_centers(sum_delegates, nb_rows, radius)
         draw_svg(svg_filename, sum_delegates, party_list, pos_list, radius)
@@ -300,7 +300,7 @@ def write_svg_seats(out_file, party_list, positions_list, radius):
 
         party_nb_seats = party_list[i]['nb_seats']
         party_fill_color = party_list[i]['color']
-        party_border_width = party_list[i]['border_size'] * radius * 100
+        party_border_width = party_list[i]['border_size'] * radius * 100 * .8
         party_border_color = party_list[i]['border_color']
 
         out_file.write(  # <g> header
@@ -316,7 +316,7 @@ def write_svg_seats(out_file, party_list, positions_list, radius):
         for j in range(drawn_spots, drawn_spots + party_nb_seats):
             x = 5.0 + 100.0 * positions_list[j][1]
             y = 5.0 + 100.0 * (1.75 - positions_list[j][2])
-            r = radius * 100.0 - party_border_width / 2.0
+            r = radius * 100.0 * .8 - party_border_width / 2.0
             out_file.write(  # <circle> element
                 '            <circle cx="{0:.2f}" cy="{1:.2f}" r="{2:.2f}"/> \n'
                 .format(x, y, r))


### PR DESCRIPTION
The `TOTALS` list was replaced with a generating function called Totals. It doesn't generate exactly the same numbers, but I believe this is for the better.

Math explaination for its code :
Assuming 1 to be the total width or diameter of the hemicycle, accounting for the thickness of the outer row's seats.
`rad` is the radius of the seats/circles, if they were to touch each of their neighbors without margins (which are ignored for the calculation)
`r` is the number of the row considered (starting from the innermost one)
`R` is the radius of the `r` row, considering it as a circle which would cross the center of each seat in the row
`tot` sums up the maximum number of seats which can fit in each row

I tested the formula in a version of this ported to another render engine, which can be found [here](https://github.com/Gouvernathor/renpy-ParliamentDiagram) and which works perfectly. However, I expect some of the code here will have to be adapted for it to place the seats in an optimized fashion.

This has the side-effect of removing the maximum number of seats a diagram can fit.