### PR TITLE
Fix position of the number of seats

### DIFF
--- a/newarch.py
+++ b/newarch.py
@@ -375,7 +375,7 @@ def write_svg_header(out_file):
 def write_svg_number_of_seats(out_file, nb_seats):
     # Print the number of seats in the middle at the bottom.
     out_file.write(
-        '        <text x="175" y="175" \n'
+        '        <text x="180" y="180" \n'
         '              style="font-size:36px;font-weight:bold;text-align:center;text-anchor:middle;font-family:sans-serif">\n'
         '            {}\n'
         '        </text>\n'


### PR DESCRIPTION
The canvas is supposed to be 350 by 175 pixels, with 5 pixels blank border on all four sides, which makes 360 by 185 total.
https://github.com/slashme/parliamentdiagram/blob/0a37d29b8c9724860a1b981af853f3c7222f87e4/newarch.py#L369-L370
The center of the bottom of the text need to find itself at the bottom center of the **margin-less** canvas. That means at position 175 (350/2) by 175. That was the position given to the text in the code : 175 by 175.
BUT if you take the margins into account (the top one and the left one to be specific), that must become the position 180 by 180.

The text was visibly offset to the left (and has been for a long time !), with 180 it doesn't appear to be. The vertical position is a bit less important, 180 makes it good math-wise so 🤷 but I could hear the argument that 175 vertically looks better.