### PR TITLE
Remove spaces from number of seats

### DIFF
--- a/newarch.py
+++ b/newarch.py
@@ -376,9 +376,7 @@ def write_svg_number_of_seats(out_file, nb_seats):
     # Print the number of seats in the middle at the bottom.
     out_file.write(
         '        <text x="175" y="175" \n'
-        '              style="font-size:36px;font-weight:bold;text-align:center;text-anchor:middle;font-family:sans-serif">\n'
-        '            {}\n'
-        '        </text>\n'
+        '              style="font-size:36px;font-weight:bold;text-align:center;text-anchor:middle;font-family:sans-serif">{}</text>\n'
         .format(nb_seats))
 
 


### PR DESCRIPTION
The current version adds several spaces before and after the number of seats. When Wikipedia generates the image, the spaces make the number off-centered. I propose removing these spaces.